### PR TITLE
Reactor/json as final step

### DIFF
--- a/src/agent/loops/react.rs
+++ b/src/agent/loops/react.rs
@@ -2,27 +2,28 @@ use super::traits::AgentLoop;
 
 use crate::agent::request::AgentRequest;
 use crate::agent::error::AgentError;
-
 use crate::core::error::ProviderError;
-use crate::core::session::{AgentOutcome , Model};
+use crate::core::session::Model;
 use crate::core::llm_client::LLMProvider;
 
 use serde_json::Value;
 
-pub struct ReactLoop{
-    model:Model,
+pub struct ReactLoop {
+    model: Model,
 }
+
 impl ReactLoop {
-    pub fn new(model:Model)->ReactLoop{
+    pub fn new(model: Model) -> ReactLoop {
         ReactLoop { model }
     }
 }
-impl AgentLoop for ReactLoop {
 
-    #[tracing::instrument(skip(self , req , provider), fields(loop_kind = "React"))]
-    async fn agent_loop(&mut self,req: AgentRequest,provider: &mut impl LLMProvider,) -> Result<Value, AgentError> {
+impl AgentLoop for ReactLoop {
+    #[tracing::instrument(skip(self, req, provider), fields(loop_kind = "React"))]
+    async fn agent_loop(&mut self, req: AgentRequest, provider: &mut impl LLMProvider) -> Result<Value, AgentError> {
         let tools = Self::build_tools_registry(&req);
-        let mut session = Self::build_attempt_session(&tools, &req , self.model.clone());
+        let mut session = Self::build_attempt_session(&tools, &req, self.model.clone());
+        let mut last_args: Option<Value> = None;
 
         loop {
             if session.steps_exhausted() {
@@ -30,7 +31,12 @@ impl AgentLoop for ReactLoop {
                 return Err(AgentError::StepsExhausted);
             }
 
-            match provider.complete(&session).await {
+            if session.is_resolved() {
+                return Ok(last_args.unwrap());
+            }
+
+            let call = match provider.complete(&session).await {
+                Ok(call) => call,
                 Err(ProviderError::InvalidToolCal { source }) => {
                     tracing::warn!(%source, "invalid tool call, recovering and continuing");
                     let available: Vec<_> = tools.keys().copied().collect();
@@ -40,24 +46,22 @@ impl AgentLoop for ReactLoop {
                     ));
                     continue;
                 }
-
                 Err(e) => return Err(e.into()),
+            };
 
-                Ok(AgentOutcome::FinalAnswer { arguments }) => {
-                    self.validate_contract(&arguments, &req.contract)?;
-                    return Ok(arguments);
+            tracing::info!(tool = %call.name(), args = %call.arguments(), "executing tool");
+
+            let result = match tools[call.name()].execute(call.arguments().clone()) {
+                Ok(result) => result,
+                Err(e) => {
+                    tracing::warn!(tool = %call.name(), error = %e, "tool execution failed");
+                    session.add_error(format!("Tool '{}' failed: {}", call.name(), e));
+                    continue;
                 }
-
-                Ok(AgentOutcome::Tool { name, id, arguments }) => {
-                    tracing::info!(tool = %name, args = %arguments, "executing tool");
-                    let result = tools[name.as_str()]
-                        .execute(arguments.clone())
-                        .map_err(|e| AgentError::Internal(e.into()))?;
-
-                    session.add_tool_call(name.clone(), arguments, id.clone());
-                    session.add_tool_result(name, result, id);
-                }
-            }
+            };
+            last_args = Some(call.arguments().clone());
+            session.add_tool_call(call.name(), call.arguments().clone(), call.id());
+            session.add_tool_result(call.name(), result, call.id());
         }
     }
 }

--- a/src/agent/loops/reflect.rs
+++ b/src/agent/loops/reflect.rs
@@ -152,6 +152,7 @@ impl AgentLoop for ReflexionLoop {
                         }
                         self.reflections.push(reflection.clone());
                         session.add_reflection(reflection);
+                        session.lock_to_final_answer();
                     }
                 }
                 continue;
@@ -161,17 +162,19 @@ impl AgentLoop for ReflexionLoop {
                 Ok(call) => call,
                 Err(ProviderError::InvalidToolCal { source }) => {
                     tracing::warn!(%source, "invalid tool call, recovering and continuing");
-                    let available: Vec<_> = tools.keys().copied().collect();
-                    session.add_error(format!(
-                        "Invalid tool call!:\nOnly Available tools:{}",
-                        available.join(", ")
-                    ));
+                    let compressed = source.to_string() 
+                        .lines()
+                        .take(3)
+                        .collect::<Vec<_>>()
+                        .join("\n");
+
+                    session.add_error(format!("Invalid tool call!:\n{}",compressed));
                     continue;
                 }
                 Err(e) => return Err(e.into()),
             };
 
-            tracing::info!(tool = %call.name(), args = %call.arguments(), "executing tool");
+            tracing::info!(tool = %call.name(),"executing tool");
 
             let result = match tools[call.name()].execute(call.arguments().clone()) {
                 Ok(result) => result,

--- a/src/agent/loops/reflect.rs
+++ b/src/agent/loops/reflect.rs
@@ -229,7 +229,7 @@ mod tests {
         );
 
         assert_eq!(session.available_tools.len(), 1);
-        assert_eq!(session.available_tools[0].name, "json");
+        assert_eq!(session.available_tools[0].name, "final_answer");
 
         let system_count = session.events.iter()
             .filter(|e| matches!(e, ConversationEvent::System(_)))

--- a/src/agent/loops/reflect.rs
+++ b/src/agent/loops/reflect.rs
@@ -3,10 +3,10 @@ use crate::agent::request::AgentRequest;
 use crate::agent::error::AgentError;
 use crate::utils::FlatSchema;
 use crate::core::error::ProviderError;
-use crate::core::session::{AgentOutcome, ConversationEvent , Model};
+use crate::core::session::{ConversationEvent, Model};
 use crate::core::llm_client::LLMProvider;
-use crate::core::capability::{Capability, FinalAnswer};
 use crate::core::session::AgentSession;
+use crate::core::capability::ToolNames;
 use serde_json::Value;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -20,19 +20,19 @@ impl FlatSchema for Reflect {}
 
 pub struct ReflexionLoop {
     evaluator: fn(&Value) -> Option<String>,
-    exec_model:Model,
-    reflexion_model:Model,
+    exec_model: Model,
+    reflexion_model: Model,
     reflections: Vec<String>,
 }
 
 impl ReflexionLoop {
-    pub fn new(evaluator: fn(&Value)->Option<String> , exec_model:Model , reflexion_model:Model) -> Self {
-        ReflexionLoop { evaluator,exec_model, reflexion_model ,reflections: vec![] }
+    pub fn new(evaluator: fn(&Value) -> Option<String>, exec_model: Model, reflexion_model: Model) -> Self {
+        ReflexionLoop { evaluator, exec_model, reflexion_model, reflections: vec![] }
     }
 
     pub fn build_reflection_session(&self, failure_reason: &str, attempt_session: &AgentSession) -> AgentSession {
-        let reflect_tool = FinalAnswer { properties: Reflect::schema() }.metadata();
-        let mut session = AgentSession::new(vec![reflect_tool], 3 , self.reflexion_model.clone());
+        let reflect_capability = ToolNames::Json(Reflect::schema()).to_capability();
+        let mut session = AgentSession::new(vec![reflect_capability.metadata()], 3, self.reflexion_model.clone());
 
         let original_goal = attempt_session.events.iter().find_map(|e| {
             if let ConversationEvent::User(message) = e {
@@ -76,49 +76,58 @@ impl ReflexionLoop {
 
         session
     }
-
     async fn reflect(
-        &self,
-        failure_reason: &str,
-        provider: &mut impl LLMProvider,
-        attempt_session: &AgentSession,
-    ) -> Result<String, AgentError> {
-        let mut session = self.build_reflection_session(failure_reason, attempt_session);
-        let contract = FinalAnswer { properties: Reflect::schema() }.metadata().parameters;
+    &self,
+    failure_reason: &str,
+    provider: &mut impl LLMProvider,
+    attempt_session: &AgentSession,
+) -> Result<String, AgentError> {
+    let mut session = self.build_reflection_session(failure_reason, attempt_session);
+    let reflect_capability = ToolNames::Json(Reflect::schema()).to_capability();
+    let mut last_args: Option<Value> = None;
 
-        loop {
-            if session.steps_exhausted() {
-                return Err(AgentError::StepsExhausted);
-            }
-            match provider.complete(&session).await {
-                Err(ProviderError::InvalidToolCal { source }) => {
-                    session.add_error(source.to_string());
-                    continue;
-                }
-                Err(e) => return Err(e.into()),
-
-                Ok(AgentOutcome::FinalAnswer { arguments }) => {
-                    self.validate_contract(&arguments, &contract)?;
-                    let reflect: Reflect = serde_json::from_value(arguments).unwrap();
-                    return Ok(reflect.reflection);
-                }
-
-                Ok(AgentOutcome::Tool { .. }) => {
-                    session.add_error(
-                        "Tool calls are not allowed in reflection session. You MUST call the final_answer tool with your reflection.".into()
-                    );
-                    continue;
-                }
-            }
+    loop {
+        if session.steps_exhausted() {
+            return Err(AgentError::StepsExhausted);
         }
+
+        if session.is_resolved() {
+            let reflect: Reflect = serde_json::from_value(last_args.unwrap())
+                .expect("Json tool validated schema — deserialization cannot fail");
+            return Ok(reflect.reflection);
+        }
+
+        let call = match provider.complete(&session).await {
+            Ok(call) => call,
+            Err(ProviderError::InvalidToolCal { source }) => {
+                session.add_error(source.to_string());
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        let result = match reflect_capability.execute(call.arguments().clone()) {
+            Ok(result) => result,
+            Err(e) => {
+                session.add_error(format!("Tool '{}' failed: {}", call.name(), e));
+                continue;
+            }
+        };
+
+        last_args = Some(call.arguments().clone());
+        session.add_tool_call(call.name(), call.arguments().clone(), call.id());
+        session.add_tool_result(call.name(), result, call.id());
     }
+}
+   
 }
 
 impl AgentLoop for ReflexionLoop {
-    #[tracing::instrument(skip(self , req , provider), fields(loop_kind = "Reflection"))]
-    async fn agent_loop(&mut self,req: AgentRequest,provider: &mut impl LLMProvider) -> Result<Value, AgentError> {
+    #[tracing::instrument(skip(self, req, provider), fields(loop_kind = "Reflection"))]
+    async fn agent_loop(&mut self, req: AgentRequest, provider: &mut impl LLMProvider) -> Result<Value, AgentError> {
         let tools = Self::build_tools_registry(&req);
-        let mut session = Self::build_attempt_session(&tools, &req , self.exec_model.clone());
+        let mut session = Self::build_attempt_session(&tools, &req, self.exec_model.clone());
+        let mut last_args: Option<Value> = None;
 
         loop {
             if session.steps_exhausted() {
@@ -126,7 +135,30 @@ impl AgentLoop for ReflexionLoop {
                 return Err(AgentError::StepsExhausted);
             }
 
-            match provider.complete(&session).await {
+            if session.is_resolved() {
+                let args = last_args.as_ref().unwrap();
+                match (self.evaluator)(args) {
+                    None => {
+                        tracing::info!("task completed successfully");
+                        return Ok(args.clone());
+                    }
+                    Some(failure_reason) => {
+                        tracing::warn!(reason = %failure_reason, "answer failed evaluation, reflecting");
+                        let reflection = self.reflect(&failure_reason, provider, &session).await?;
+
+                        session.clear_resolved();
+                        if self.reflections.len() == 3 {
+                            self.reflections.remove(0);
+                        }
+                        self.reflections.push(reflection.clone());
+                        session.add_reflection(reflection);
+                    }
+                }
+                continue;
+            }
+
+            let call = match provider.complete(&session).await {
+                Ok(call) => call,
                 Err(ProviderError::InvalidToolCal { source }) => {
                     tracing::warn!(%source, "invalid tool call, recovering and continuing");
                     let available: Vec<_> = tools.keys().copied().collect();
@@ -137,43 +169,25 @@ impl AgentLoop for ReflexionLoop {
                     continue;
                 }
                 Err(e) => return Err(e.into()),
+            };
 
-                Ok(AgentOutcome::FinalAnswer { arguments }) => {
-                    match (self.evaluator)(&arguments) {
-                        None => {
-                            self.validate_contract(&arguments, &req.contract)?;
-                            tracing::info!("Task completed succesfully");
-                            return Ok(arguments);
-                        }
-                        Some(failure_reason) => {
-                            tracing::warn!(reason = %failure_reason, "answer failed evaluation, reflecting");
-                            let reflection = self.reflect(&failure_reason, provider, &session).await?;
+            tracing::info!(tool = %call.name(), args = %call.arguments(), "executing tool");
 
-                            session.lock_to_final_answer();
-
-                            if self.reflections.len() == 3 {
-                                self.reflections.remove(0);
-                            }   
-                            self.reflections.push(reflection.clone());
-                            session.add_reflection(reflection);
-                        }
-                    }
+            let result = match tools[call.name()].execute(call.arguments().clone()) {
+                Ok(result) => result,
+                Err(e) => {
+                    tracing::warn!(tool = %call.name(), error = %e, "tool execution failed");
+                    session.add_error(format!("Tool '{}' failed: {}", call.name(), e));
+                    continue;
                 }
+            };
 
-                Ok(AgentOutcome::Tool { name, id, arguments }) => {
-                    tracing::info!(tool = %name, args = %arguments, "executing tool");
-                    let result = tools[name.as_str()]
-                        .execute(arguments.clone())
-                        .map_err(|e| AgentError::Internal(e.into()))?;
-                    session.add_tool_call(name.clone(), arguments, id.clone());
-                    session.add_tool_result(name, result, id);
-                }
-            }
+            last_args = Some(call.arguments().clone());
+            session.add_tool_call(call.name(), call.arguments().clone(), call.id());
+            session.add_tool_result(call.name(), result, call.id());
         }
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {
@@ -181,7 +195,7 @@ mod tests {
     use crate::core::session::{AgentSession, Model, ModelName};
     use crate::groq::client::GroqClient;
     use serde_json::json;
-    
+
     fn make_attempt_session() -> AgentSession {
         let mut session = AgentSession::new(vec![], 10, Model::with_default_temp(ModelName::GptOss120B));
         session.add_system("You are an expert bash execution agent embedded in a developer's shell.");
@@ -190,22 +204,19 @@ mod tests {
         session.add_tool_result(
             "find_files",
             "find . -mtime -7 -printf '%s %p\\n' | sort -rn | head -3",
-            "call_1"
+            "call_1",
         );
         session.add_tool_call("execute_script", json!({}), "call_2");
         session.add_tool_result(
             "execute_script",
             "find: illegal option -- -printf\nusage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]",
-            "call_2"
+            "call_2",
         );
         session
     }
 
-    // ── unit tests ────────────────────────────────────────────────────────────
-
     #[test]
-    #[ignore]
-    fn test_build_reflection_session_structure() {
+    fn build_reflection_session_structure() {
         let loop_ = ReflexionLoop::new(
             |_| None,
             Model::with_default_temp(ModelName::GptOss120B),
@@ -218,15 +229,13 @@ mod tests {
         );
 
         assert_eq!(session.available_tools.len(), 1);
-        assert_eq!(session.available_tools[0].name, "final_answer");
+        assert_eq!(session.available_tools[0].name, "json");
 
-        // single system message
         let system_count = session.events.iter()
             .filter(|e| matches!(e, ConversationEvent::System(_)))
             .count();
         assert_eq!(system_count, 1);
 
-        // system message contains all parts
         if let ConversationEvent::System(msg) = &session.events[0] {
             assert!(msg.contains("Plan"), "missing framing instruction");
             assert!(msg.contains("Find the 3 largest files"), "missing original goal");
@@ -234,17 +243,14 @@ mod tests {
             assert!(!msg.contains("Previous reflections"), "should have no reflections yet");
         }
 
-        // last event is user with failure cue
         assert!(matches!(
             session.events.last(),
             Some(ConversationEvent::User(msg)) if msg.contains("Plan:")
         ));
-        println!("{:?}", session.events());
     }
 
     #[test]
-    #[ignore]
-    fn test_build_reflection_session_injects_previous_reflections() {
+    fn build_reflection_session_injects_previous_reflections() {
         let mut loop_ = ReflexionLoop::new(
             |_| None,
             Model::with_default_temp(ModelName::GptOss120B),
@@ -267,8 +273,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    fn test_reflections_capped_at_3() {
+    fn reflections_capped_at_3() {
         let mut loop_ = ReflexionLoop::new(
             |_| None,
             Model::with_default_temp(ModelName::GptOss120B),
@@ -280,7 +285,6 @@ mod tests {
             "reflection 3".into(),
         ];
 
-        // simulate what agent_loop does when adding a 4th
         if loop_.reflections.len() == 3 {
             loop_.reflections.remove(0);
         }
@@ -291,35 +295,10 @@ mod tests {
         assert!(loop_.reflections.contains(&"reflection 4".to_string()));
     }
 
-    // ── integration tests ─────────────────────────────────────────────────────
 
     #[tokio::test]
     #[ignore = "requires GROQ_API_KEY"]
-    async fn test_reflect_produces_plan() {
-        let mut provider = GroqClient::default();
-        let loop_ = ReflexionLoop::new(
-            |_| None,
-            Model::with_default_temp(ModelName::GptOss120B),
-            Model::deterministic(ModelName::Llma3p370B),
-        );
-        let attempt = make_attempt_session();
-
-        let result = loop_.reflect(
-            "script failed with exit code 1. stderr: find: illegal option -- -printf. \
-             This is macOS which uses BSD find — -printf is a GNU extension and not available.",
-            &mut provider,
-            &attempt,
-        ).await;
-
-        assert!(result.is_ok());
-        let reflection = result.unwrap();
-        assert!(!reflection.is_empty());
-        println!("reflection:\n{reflection}");
-    }
-
-    #[tokio::test]
-    #[ignore = "requires GROQ_API_KEY"]
-    async fn test_reflect_with_previous_reflections() {
+    async fn reflect_with_previous_reflections() {
         let mut provider = GroqClient::default();
         let mut loop_ = ReflexionLoop::new(
             |_| None,
@@ -327,7 +306,7 @@ mod tests {
             Model::deterministic(ModelName::Llma3p370B),
         );
         loop_.reflections.push(
-            "Plan: Use BSD find syntax. Replace -printf with -exec stat.".into()
+            "Plan: Use BSD find syntax. Replace -printf with -exec stat.".into(),
         );
 
         let attempt = make_attempt_session();
@@ -344,8 +323,6 @@ mod tests {
         println!("reflection with prior context:\n{reflection}");
     }
 }
-
-
 
 #[cfg(test)]
 mod integration_tests {
@@ -377,7 +354,7 @@ mod integration_tests {
     Never modify system files.
 
     OUTPUT:
-    You MUST submit your final script using the final_answer tool — this is the only valid way to produce output.
+    You MUST submit your final script using the json tool — this is the only valid way to produce output.
     The script must be complete and executable as-is.
     Do NOT include comments or explanations in the script — code only.";
 
@@ -399,14 +376,13 @@ mod integration_tests {
             return Some("script is missing shebang".into());
         }
 
-        // create temp dir as safe sandbox
         let tmp_dir = tempfile::TempDir::new().ok()?;
         let script_path = tmp_dir.path().join("script.sh");
         std::fs::write(&script_path, &script.script).ok()?;
 
         let output = std::process::Command::new("bash")
             .arg(&script_path)
-            .current_dir(tmp_dir.path())  // run from inside temp dir
+            .current_dir(tmp_dir.path())
             .output()
             .ok()?;
 
@@ -419,24 +395,20 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore = "requires GROQ_API_KEY"]
-    async fn test_reflexion_loop_produces_valid_script() {
-
+    async fn reflexion_loop_produces_valid_script() {
         let file_appender = tracing_appender::rolling::daily("./logs", "app.log");
         let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
         tracing_subscriber::registry()
-            .with(
-                tracing_subscriber::fmt::layer().with_ansi(false)
-            )
+            .with(tracing_subscriber::fmt::layer().with_ansi(false))
             .with(
                 tracing_subscriber::fmt::layer()
                     .with_writer(non_blocking)
-                    .with_ansi(false)
+                    .with_ansi(false),
             )
             .with(tracing_subscriber::EnvFilter::new("warn,smart_terminal=debug"))
             .try_init()
             .ok();
-    
 
         let mut provider = GroqClient::default();
         let mut loop_ = ReflexionLoop::new(
@@ -446,11 +418,9 @@ mod integration_tests {
         );
 
         let req = AgentRequest::builder()
-            .tools(vec![ToolNames::GitStatus, ToolNames::GitLog, ToolNames::GitDiffStaged])
-            .contract(Script::schema())
+            .tools(vec![ToolNames::Json(Script::schema()),ToolNames::GitStatus, ToolNames::GitLog, ToolNames::GitDiffStaged])
             .with_system_promt(TEST_POLICY.into())
-            .with_user_promt("".into());
-
+            .with_user_promt("Find most user commands from histroy".into());
 
         let result = loop_.agent_loop(req, &mut provider).await;
 

--- a/src/agent/loops/traits.rs
+++ b/src/agent/loops/traits.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use crate::core::llm_client::LLMProvider;
-use crate::core::capability::{Capability , ToolFunction , FinalAnswer};
+use crate::core::capability::{Capability , ToolFunction};
 use crate::core::session::{AgentSession , ConversationEvent , Model};
 use crate::agent::error::AgentError;
 use crate::agent::request::AgentRequest;
@@ -23,11 +23,9 @@ pub trait AgentLoop:Send{
     }
 
     fn build_attempt_session(tools: &ToolRegistry, req: &AgentRequest , model:Model) -> AgentSession {
-        let mut tool_functions: Vec<ToolFunction> = tools.values()
+        let tool_functions: Vec<ToolFunction> = tools.values()
             .map(|t| t.metadata())
             .collect();
-
-        tool_functions.push(FinalAnswer { properties: req.contract.clone() }.metadata());
 
         let mut session = AgentSession::new(tool_functions, DEFAULT_STEPS , model);
         session.events = req.messages.iter()
@@ -35,20 +33,6 @@ pub trait AgentLoop:Send{
             .collect();
 
         session
-    }
-
-    fn validate_contract(&self, response: &Value, contract: &Value) -> Result<(), AgentError> {
-        if contract.is_null() {
-            return Ok(());
-        }
-        let validator = jsonschema::validator_for(contract)
-            .map_err(|e| AgentError::InvalidContract(e.to_string()))?;
-
-        if validator.is_valid(response) {
-            Ok(())
-        } else {
-            Err(AgentError::ContractViolation)
-        }
     }
 
     fn agent_loop(&mut self, req: AgentRequest,provider: &mut impl LLMProvider,) -> impl Future<Output = Result<Value, AgentError>> + Send;

--- a/src/agent/request.rs
+++ b/src/agent/request.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use crate::core::capability::ToolNames;
 use crate::core::session::ConversationEvent;
 
@@ -8,23 +7,17 @@ use crate::core::session::ConversationEvent;
 pub struct AgentRequest {
     pub tools:Vec<ToolNames>,
     pub messages:Vec<Message>,
-    pub contract:Value,
 }
 
 impl AgentRequest {
-    pub fn new(tools: Vec<ToolNames>,messages: Vec<Message>,contract: Value) ->AgentRequest{
-        AgentRequest {tools, messages, contract}
+    pub fn new(tools: Vec<ToolNames>,messages: Vec<Message>) ->AgentRequest{
+        AgentRequest {tools, messages}
     }
     pub fn builder()-> AgentRequest{
-        AgentRequest {tools:vec![], messages:vec![], contract:Value::Null}
+        AgentRequest {tools:vec![], messages:vec![]}
     }
     pub fn tools(mut self, tools: Vec<ToolNames>) -> Self {
         self.tools = tools;
-        self
-    }
-
-    pub fn contract(mut self, contract: Value) ->  Self {
-        self.contract = contract;
         self
     }
 

--- a/src/cli/exec/mod.rs
+++ b/src/cli/exec/mod.rs
@@ -82,8 +82,8 @@ pub async fn run(args:ExecArgs){
     let provider = GroqClient::default();
     let agent_loop = ReflexionLoop::new(
           evaluation_script ,
-         Model::with_default_temp(ModelName::GptOss120B), 
-    Model::creative(ModelName::GptOss120B));
+         Model::creative(ModelName::GptOss120B), 
+    Model::deterministic(ModelName::GptOss120B));
 
     let mut agent = AgentClient::new("SHELL_AGENT", provider, agent_loop);
 
@@ -141,7 +141,7 @@ mod tests {
     #[ignore]
     async fn run_with_align_false() {
         let args = ExecArgs {
-            prompt: "Search recursively through all .rs files in the current directory for struct definitions. For each struct found determine its type: regular (has named fields with braces), tuple (has unnamed fields with parentheses), or unit (no fields, just semicolon). Extract the module path from the file path e.g. src/agent/service.rs becomes agent/service. Output the results grouped by module path with each module as a bold white header. Under each module list its structs with their type using these colors: cyan for regular structs, yellow for unit structs, green for tuple structs".to_string(),
+            prompt: "".to_string(),
             mode: Mode::Auto,
         };
         run(args).await;

--- a/src/cli/exec/policy.rs
+++ b/src/cli/exec/policy.rs
@@ -32,8 +32,7 @@ impl AgentPolicy for AutoPolicy {
 
         let terminal_ctx = ShellEnv::gather();
         AgentRequest::builder()
-            .tools(vec![ToolNames::ReadDir ,ToolNames::GitLog , ToolNames::GitDiffStaged])
-            .contract(Script::schema())
+            .tools(vec![ToolNames::Json(Script::schema()) ,ToolNames::ReadDir])
             .with_context(&terminal_ctx)
             .with_system_promt(AUTO_SYSTEM_POLICY.into())
             .with_user_promt(itend.prompt)
@@ -48,8 +47,7 @@ impl AgentPolicy for AlignPolicy{
 
         let terminal_ctx = ShellEnv::gather();
         AgentRequest::builder()
-            .tools(vec![ToolNames::AskUser, ToolNames::ReadDir])
-            .contract(Script::schema())
+            .tools(vec![ToolNames::Json(Script::schema()),ToolNames::AskUser, ToolNames::ReadDir])
             .with_context(&terminal_ctx)
             .with_system_promt(ALIGN_SYSTEM_POLICY.into())
             .with_user_promt(itend.prompt)

--- a/src/cli/next_cmd/mod.rs
+++ b/src/cli/next_cmd/mod.rs
@@ -16,8 +16,7 @@ pub async fn run(args:NextCmdArgs){
 
     let mut agent = AgentClient::new("NEXT_CMD_AGENT", provider, agent_loop);
 
-    let policy = Policy::select_policy();
-    let req = policy.create_req(itend);
+    let req = Policy::select_policy().create_req(itend);
     let response = agent.execute_request(req).await;
 
 

--- a/src/cli/next_cmd/policy.rs
+++ b/src/cli/next_cmd/policy.rs
@@ -43,8 +43,7 @@ impl AgentPolicy for DefaultPolicy {
 
         let terminal_ctx = ShellEnv::gather();
         AgentRequest::builder()
-            .tools(vec![ToolNames::GitLog , ToolNames::GitDiffStaged])
-            .contract(NextCommand::schema())
+            .tools(vec![ToolNames::Json(NextCommand::schema()) ,ToolNames::GitLog , ToolNames::GitDiffStaged])
             .with_system_promt(DEFAULT_SYSTEM_POLICY.into())
             .with_user_promt(itend.prompt)
             .with_context(&terminal_ctx)

--- a/src/core/capability.rs
+++ b/src/core/capability.rs
@@ -5,6 +5,7 @@ use crate::tools::git_status::GitStatus;
 use crate::tools::git_diff::GitDiffStaged;
 use crate::tools::git_log::GitLog;
 use crate::tools::ask_user::AskUser;
+use crate::tools::json::Json;
 use crate::tools::read_dir::ReadDir;
 use crate::tools::error::ToolError;
 
@@ -12,11 +13,11 @@ use crate::tools::error::ToolError;
 #[derive(Serialize , Deserialize , PartialEq, Eq , JsonSchema , Debug , Clone)]
 pub enum ToolNames{
     GitStatus,
-    FinalAnswer,
     GitDiffStaged,
     GitLog,
     AskUser,
     ReadDir,
+    Json(Value)
 }
 
 impl ToolNames {
@@ -24,7 +25,7 @@ impl ToolNames {
         match self {
             ToolNames::GitStatus =>   Box::new(GitStatus),
             ToolNames::GitDiffStaged => Box::new(GitDiffStaged),
-            ToolNames::FinalAnswer => Box::new(FinalAnswer{properties:Value::Null}),
+            ToolNames::Json(value) => Box::new(Json{ properties:value.clone()}),
             ToolNames::GitLog =>  Box::new(GitLog), 
             ToolNames::AskUser => Box::new(AskUser),
             ToolNames::ReadDir => Box::new(ReadDir),
@@ -46,29 +47,4 @@ pub trait Capability:Send + Sync{
     fn arg_schema(&self) -> Option<&Value> {
         None
     }
-}
-pub struct FinalAnswer {
-    pub properties: Value,
-}
-
-impl Capability for FinalAnswer {
-    fn name(&self) -> &'static str {
-        "final_answer"
-    }
-
-    fn metadata(&self) -> ToolFunction{
-        ToolFunction {
-            name: self.name().into(),
-            description:"You MUST use this tool for your final answer.".into(),
-            parameters:self.properties.clone(),
-        }
-    }
-
-    fn execute(&self, _args: Value) -> Result<String,  ToolError> {
-        Err(ToolError::ToolExecution{source: anyhow::anyhow!("FinalAnswer tool should not be called.")})
-    }
-    fn arg_schema(&self) -> Option<&Value> {
-        Some(&self.properties)
-    }
-
 }

--- a/src/core/llm_client.rs
+++ b/src/core/llm_client.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
-use super::session::{AgentSession, AgentOutcome};
+use super::session::{AgentSession, AgentToolCall};
 use super::error::ProviderError;
 
 pub trait LLMProvider: Send {
-    fn complete(&mut self, request: &AgentSession) -> impl Future<Output = Result<AgentOutcome, ProviderError>> + Send;
+    fn complete(&mut self, request: &AgentSession) -> impl Future<Output = Result<AgentToolCall, ProviderError>> + Send;
 }

--- a/src/core/session.rs
+++ b/src/core/session.rs
@@ -74,35 +74,49 @@ pub enum ConversationEvent {
 }
 
 #[derive(Debug)]
-pub enum AgentOutcome{
-
-    FinalAnswer{
-        arguments:Value
-    },
-    Tool{
-        name: String,
-        id: String,
-        arguments: Value,
-    },
+ pub struct AgentToolCall{
+    id: String,
+    arguments: Value,
+    name: String,
+}
+impl AgentToolCall {
+    pub fn new(name: String, id: String, arguments: Value) -> Self {
+        Self { name, id, arguments }
+    }
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+    pub fn arguments(&self) -> &Value {
+        &self.arguments
+    }
+    pub fn into_arguments(self) -> Value {
+        self.arguments
+    }
 }
 
 #[derive(Debug)]
-pub struct AgentSession{
-    pub events:Vec<ConversationEvent>,
-    pub available_tools:Vec<ToolFunction>,
-    pub steps:usize,
-    pub model:Model,
+pub struct AgentSession {
+    pub events: Vec<ConversationEvent>,
+    pub available_tools: Vec<ToolFunction>,
+    pub steps: usize,
+    pub model: Model,
+    pub last_tool: Option<String>,
 }
 
 impl AgentSession {
-    pub fn new(available_tools: Vec<ToolFunction>, steps: usize , model:Model) -> Self {
+    pub fn new(available_tools: Vec<ToolFunction>, steps: usize, model: Model) -> Self {
         Self {
             events: Vec::new(),
             available_tools,
             steps,
-            model
+            model,
+            last_tool: None,
         }
     }
+
     pub fn add_system(&mut self, message: impl Into<String>) {
         self.events.push(ConversationEvent::System(message.into()));
     }
@@ -111,30 +125,40 @@ impl AgentSession {
         self.events.push(ConversationEvent::User(message.into()));
     }
 
-    pub fn add_outcome(&mut self, outcome: AgentOutcome) {
-        match outcome {
-            AgentOutcome::Tool { name, id, arguments } => {
-                self.events.push(ConversationEvent::ToolCall { name, arguments, id });
-            }
-            AgentOutcome::FinalAnswer { .. } => {}
-        }
-    }
     pub fn add_reflection(&mut self, reflection: impl Into<String>) {
         self.events.push(ConversationEvent::System(
-            format!("[REFLECTION] {}", reflection.into())
+            format!("[REFLECTION] {}", reflection.into()),
         ));
-}
+    }
 
-    pub fn add_tool_call(&mut self, name: impl Into<String>, arguments:Value, id: impl Into<String>) {
-         self.events.push(ConversationEvent::ToolCall { name:name.into(), arguments,id:id.into() });
+    pub fn add_tool_call(&mut self, name: impl Into<String>, arguments: Value, id: impl Into<String>) {
+        let name = name.into();
+        self.last_tool = Some(name.clone());
+        self.events.push(ConversationEvent::ToolCall {
+            name,
+            arguments,
+            id: id.into(),
+        });
     }
 
     pub fn add_tool_result(&mut self, name: impl Into<String>, result: impl Into<String>, id: impl Into<String>) {
-        self.tool_result_event(name.into(), result.into(), id.into());
+        self.events.push(ConversationEvent::ToolResult {
+            name: name.into(),
+            result: result.into(),
+            id: id.into(),
+        });
     }
 
-    pub fn is_final(outcome: &AgentOutcome) -> bool {
-        matches!(outcome, AgentOutcome::FinalAnswer { .. })
+    pub fn add_error(&mut self, er: String) {
+        self.events.push(ConversationEvent::System(er));
+    }
+
+    pub fn is_resolved(&self) -> bool {
+        self.last_tool.as_deref() == Some("final_answer")
+    }
+
+    pub fn clear_resolved(&mut self) {
+        self.last_tool = None;
     }
 
     pub fn current_steps(&self) -> usize {
@@ -153,32 +177,14 @@ impl AgentSession {
         self.events.is_empty()
     }
 
-    pub fn add_error(&mut self, er: String) {
-        self.events.push(ConversationEvent::System(er));
-    }
-
-    fn _tool_call_event(&mut self, tool_call: AgentOutcome) {
-        match tool_call {
-            AgentOutcome::Tool { name, id, arguments } => {
-                self.events.push(ConversationEvent::ToolCall { name, arguments, id });
-            }
-            _ => {}
-        }
-    }
-    fn tool_result_event(&mut self, name: String, result: String, id: String) {
-        self.events.push(ConversationEvent::ToolResult { name, result, id });
-    }
-
-    /// Remove all tools except final_answer
     pub fn lock_to_final_answer(&mut self) {
         self.available_tools.retain(|t| t.name == "final_answer");
     }
-    pub fn get_model(&self)->&Model{
+
+    pub fn get_model(&self) -> &Model {
         &self.model
     }
-
 }
-
 
 
 
@@ -190,11 +196,11 @@ mod tests {
     use serde_json::json;
 
     fn make_session(steps: usize) -> AgentSession {
-        AgentSession::new(vec![], steps , Model::new(ModelName::GptOss120B , 0.5))
+        AgentSession::new(vec![], steps, Model::new(ModelName::GptOss120B, 0.5))
     }
 
-    fn make_tool_outcome(name: &str, id: &str) -> AgentOutcome {
-        AgentOutcome::Tool {
+    fn make_tool_call(name: &str, id: &str) -> AgentToolCall {
+        AgentToolCall {
             name: name.to_string(),
             id: id.to_string(),
             arguments: json!({}),
@@ -202,15 +208,16 @@ mod tests {
     }
 
     #[test]
-    fn test_new_session_is_empty() {
+    fn new_session_is_empty() {
         let session = make_session(5);
         assert!(session.is_empty());
         assert_eq!(session.current_steps(), 0);
         assert_eq!(session.steps, 5);
+        assert!(!session.is_resolved());
     }
 
     #[test]
-    fn test_add_system_event() {
+    fn add_system_event() {
         let mut session = make_session(5);
         session.add_system("you are a helpful assistant");
         assert_eq!(session.events().len(), 1);
@@ -218,59 +225,26 @@ mod tests {
     }
 
     #[test]
-    fn test_add_user_event() {
+    fn add_user_event() {
         let mut session = make_session(5);
         session.add_user("hello");
         assert!(matches!(&session.events()[0], ConversationEvent::User(msg) if msg == "hello"));
     }
 
     #[test]
-    fn test_add_tool_outcome_pushes_tool_call() {
+    fn add_tool_call_pushes_event_and_tracks_name() {
         let mut session = make_session(5);
-        session.add_outcome(make_tool_outcome("search", "id-1"));
+        let call = make_tool_call("search", "id-1");
+        session.add_tool_call(call.name, call.arguments, call.id);
         assert_eq!(session.current_steps(), 1);
-        assert!(matches!(&session.events()[0], ConversationEvent::ToolCall { name, id, .. } if name == "search" && id == "id-1"));
+        assert!(matches!(
+            &session.events()[0],
+            ConversationEvent::ToolCall { name, id, .. } if name == "search" && id == "id-1"
+        ));
     }
 
     #[test]
-    fn test_add_final_answer_pushes_no_event() {
-        let mut session = make_session(5);
-        session.add_outcome(AgentOutcome::FinalAnswer { arguments: json!({"answer": "42"}) });
-        assert!(session.is_empty());
-        assert_eq!(session.current_steps(), 0);
-    }
-
-    #[test]
-    fn test_is_final() {
-        let tool = make_tool_outcome("search", "id-1");
-        let final_answer = AgentOutcome::FinalAnswer { arguments: json!({}) };
-        assert!(!AgentSession::is_final(&tool));
-        assert!(AgentSession::is_final(&final_answer));
-    }
-
-    #[test]
-    fn test_steps_exhausted() {
-        let mut session = make_session(2);
-        assert!(!session.steps_exhausted());
-
-        session.add_outcome(make_tool_outcome("search", "id-1"));
-        assert!(!session.steps_exhausted());
-
-        session.add_outcome(make_tool_outcome("search", "id-2"));
-        assert!(session.steps_exhausted());
-    }
-
-    #[test]
-    fn test_steps_not_exhausted_by_non_tool_events() {
-        let mut session = make_session(2);
-        session.add_system("system prompt");
-        session.add_user("user message");
-        assert!(!session.steps_exhausted());
-        assert_eq!(session.current_steps(), 0);
-    }
-
-    #[test]
-    fn test_add_tool_result() {
+    fn add_tool_result() {
         let mut session = make_session(5);
         session.add_tool_result("search", "some results", "id-1");
         assert!(matches!(
@@ -281,22 +255,83 @@ mod tests {
     }
 
     #[test]
-    fn test_current_steps_only_counts_tool_calls() {
+    fn is_resolved_after_final_answer() {
+        let mut session = make_session(5);
+        session.add_tool_call("final_answer", json!({"script": "echo hi"}), "id-1");
+        assert!(session.is_resolved());
+    }
+
+    #[test]
+    fn not_resolved_after_regular_tool() {
+        let mut session = make_session(5);
+        session.add_tool_call("git_status", json!({}), "id-1");
+        assert!(!session.is_resolved());
+    }
+
+    #[test]
+    fn clear_resolved_resets_state() {
+        let mut session = make_session(5);
+        session.add_tool_call("final_answer", json!({}), "id-1");
+        assert!(session.is_resolved());
+        session.clear_resolved();
+        assert!(!session.is_resolved());
+    }
+
+    #[test]
+    fn steps_exhausted() {
+        let mut session = make_session(2);
+        assert!(!session.steps_exhausted());
+
+        session.add_tool_call("search", json!({}), "id-1");
+        assert!(!session.steps_exhausted());
+
+        session.add_tool_call("search", json!({}), "id-2");
+        assert!(session.steps_exhausted());
+    }
+
+    #[test]
+    fn steps_not_exhausted_by_non_tool_events() {
+        let mut session = make_session(2);
+        session.add_system("system prompt");
+        session.add_user("user message");
+        assert!(!session.steps_exhausted());
+        assert_eq!(session.current_steps(), 0);
+    }
+
+    #[test]
+    fn current_steps_only_counts_tool_calls() {
         let mut session = make_session(10);
         session.add_system("sys");
         session.add_user("user");
-        session.add_outcome(make_tool_outcome("tool_a", "id-1"));
+        session.add_tool_call("tool_a", json!({}), "id-1");
         session.add_tool_result("tool_a", "result", "id-1");
-        session.add_outcome(make_tool_outcome("tool_b", "id-2"));
+        session.add_tool_call("tool_b", json!({}), "id-2");
 
         assert_eq!(session.current_steps(), 2);
         assert_eq!(session.events().len(), 5);
     }
 
     #[test]
-    fn test_error_event_pushes_system_message() {
+    fn error_event_pushes_system_message() {
         let mut session = make_session(5);
         session.add_error("something went wrong".to_string());
         assert!(matches!(&session.events()[0], ConversationEvent::System(msg) if msg == "something went wrong"));
+    }
+
+    #[test]
+    fn resolved_tracks_last_tool_not_history() {
+        let mut session = make_session(5);
+        session.add_tool_call("final_answer", json!({}), "id-1");
+        assert!(session.is_resolved());
+        session.add_tool_call("git_status", json!({}), "id-2");
+        assert!(!session.is_resolved());
+    }
+
+    #[test]
+    fn reflection_does_not_affect_resolution() {
+        let mut session = make_session(5);
+        session.add_tool_call("final_answer", json!({}), "id-1");
+        session.add_reflection("Use BSD find syntax");
+        assert!(session.is_resolved());
     }
 }

--- a/src/groq/adapters.rs
+++ b/src/groq/adapters.rs
@@ -50,7 +50,7 @@ impl From<&AgentSession> for GroqRequest {
             model,
             messages,
             tools,
-            tool_choice:"auto".into(),
+            tool_choice:"required".into(),
             temperature:session.get_model().get_temp()
             
         }
@@ -172,7 +172,8 @@ mod tests {
             ],
             // add other fields if needed
             steps:5,
-            model:Model::new(ModelName::GptOss120B,0.5)
+            model:Model::new(ModelName::GptOss120B,0.5),
+            last_tool:Some("".into())
         };
 
         // ---- Act ----

--- a/src/groq/client.rs
+++ b/src/groq/client.rs
@@ -1,9 +1,9 @@
 use reqwest::{Client, StatusCode };
 use crate::core::llm_client::LLMProvider;
-use crate::core::session::{AgentSession , AgentOutcome};
+use crate::core::session::{AgentSession , AgentToolCall};
 use crate::core::error::ProviderError;
 use super::error::GroqError;
-use super::protocol::responce::{GroqResponse , LlmOutcome};
+use super::protocol::responce::{GroqResponse , LlmToolCall};
 use super::protocol::request::GroqRequest;
 
 pub struct GroqClient{
@@ -94,25 +94,21 @@ impl Default for  GroqClient{
 
 impl LLMProvider for GroqClient {
 
-    async fn complete(&mut self , session:&AgentSession,)->Result<AgentOutcome,ProviderError>{
+    async fn complete(&mut self , session:&AgentSession,)->Result<AgentToolCall,ProviderError>{
         let req = GroqRequest::from(session);
         let res = self.call_llm(req).await.map_err(ProviderError::from)?;
-        let outcome = LlmOutcome::try_from(res).map_err(ProviderError::from)?;
+        let tool_call = LlmToolCall::try_from(res).map_err(ProviderError::from)?;
 
-        match outcome {
-            LlmOutcome::FinalAnswer { answer } => Ok(AgentOutcome::FinalAnswer { arguments: answer }),
-            LlmOutcome::ToolCall { name, id, args } => Ok(AgentOutcome::Tool { name, id, arguments: args }),
-        }
-    }   
+        Ok(AgentToolCall::new(tool_call.name, tool_call.id, tool_call.args))
+    }
 }
 
 #[cfg(test)]
 mod unit {
-    use crate::groq::protocol::responce::{GroqResponse, LlmOutcome};
-    use crate::core::session::AgentOutcome;
+    use crate::groq::protocol::responce::{GroqResponse, LlmToolCall};
+    use crate::core::session::AgentToolCall;
     use serde_json::json;
 
-    
     fn groq_response(tool_name: &str, arguments: &str) -> GroqResponse {
         serde_json::from_value(json!({
             "choices": [{
@@ -135,37 +131,30 @@ mod unit {
         })).unwrap()
     }
 
-    // ── LlmOutcome::try_from ───────────────────────────────────────────────
-
     #[test]
-    fn final_answer_maps_to_outcome() {
+    fn final_answer_parses_as_tool_call() {
         let resp = groq_response("final_answer", r#"{"result":"42"}"#);
-        let outcome = LlmOutcome::try_from(resp).unwrap();
-        assert!(matches!(outcome, LlmOutcome::FinalAnswer { .. }));
+        let call = LlmToolCall::try_from(resp).unwrap();
+        assert_eq!(call.name, "final_answer");
+        assert_eq!(call.args, json!({"result": "42"}));
     }
 
     #[test]
-    fn tool_call_maps_to_outcome() {
+    fn regular_tool_parses_as_tool_call() {
         let resp = groq_response("git_status", r#"{"path":"."}"#);
-        let outcome = LlmOutcome::try_from(resp).unwrap();
-        match outcome {
-            LlmOutcome::ToolCall { name, id, args } => {
-                assert_eq!(name, "git_status");
-                assert_eq!(id, "call_test");
-                assert_eq!(args, json!({"path": "."}));
-            }
-            _ => panic!("Expected ToolCall"),
-        }
+        let call = LlmToolCall::try_from(resp).unwrap();
+        assert_eq!(call.name, "git_status");
+        assert_eq!(call.id, "call_test");
+        assert_eq!(call.args, json!({"path": "."}));
     }
 
     #[test]
-    fn final_answer_converts_to_agent_outcome() {
+    fn llm_tool_call_converts_to_agent_tool_call() {
         let resp = groq_response("final_answer", r#"{"result":"42"}"#);
-        let outcome = LlmOutcome::try_from(resp).unwrap();
-        let agent_outcome = match outcome {
-            LlmOutcome::FinalAnswer { answer } => AgentOutcome::FinalAnswer { arguments: answer },
-            LlmOutcome::ToolCall { name, id, args } => AgentOutcome::Tool { name, id, arguments: args },
-        };
-        assert!(matches!(agent_outcome, AgentOutcome::FinalAnswer { .. }));
+        let llm_call = LlmToolCall::try_from(resp).unwrap();
+        let agent_call = AgentToolCall::new(llm_call.name, llm_call.id, llm_call.args);
+        assert_eq!(agent_call.name(), "final_answer");
+        assert_eq!(agent_call.id(), "call_test");
+        assert_eq!(agent_call.arguments().clone(), json!({"result": "42"}));
     }
 }

--- a/src/groq/protocol/responce.rs
+++ b/src/groq/protocol/responce.rs
@@ -1,25 +1,21 @@
-use serde::{Deserialize};
+use serde::Deserialize;
 use serde_json::Value;
 use super::message::Message;
 use crate::groq::error::GroqError;
 
-pub enum LlmOutcome{
-    FinalAnswer{
-        answer:Value,
-    },
-    ToolCall{
-        name:String,
-        id:String,
-        args:Value,
-    }
+#[derive(Debug)]
+pub struct LlmToolCall {
+    pub name: String,
+    pub id: String,
+    pub args: Value,
 }
 
-#[derive(Deserialize , Debug)]
+#[derive(Deserialize, Debug)]
 pub struct GroqResponse {
     pub choices: Vec<Choice>,
 }
 
-#[derive(Deserialize , Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Choice {
     pub index: usize,
     #[serde(default)]
@@ -27,13 +23,12 @@ pub struct Choice {
     #[serde(default)]
     pub logprobs: Option<serde_json::Value>,
     pub message: Message,
-} 
+}
 
-impl TryFrom<GroqResponse> for LlmOutcome {
+impl TryFrom<GroqResponse> for LlmToolCall {
     type Error = GroqError;
 
     fn try_from(value: GroqResponse) -> Result<Self, Self::Error> {
-
         let choice = value
             .choices
             .into_iter()
@@ -42,36 +37,29 @@ impl TryFrom<GroqResponse> for LlmOutcome {
                 source: anyhow::anyhow!("No choices in response"),
             })?;
 
-        let message = choice.message;
-        let tool_calls = message.tool_calls;
-
-        let tool = tool_calls
+        let tool = choice
+            .message
+            .tool_calls
             .into_iter()
             .next()
-            .ok_or(GroqError::InvalidToolCall{source:anyhow::anyhow!("No tools where found")})?;
+            .ok_or(GroqError::InvalidToolCall {
+                source: anyhow::anyhow!("No tools where found"),
+            })?;
 
-
-        let args_str = tool.function.arguments.ok_or(GroqError::InvalidToolCall{source:anyhow::anyhow!("No arguments where found")})?;
+        let args_str = tool.function.arguments.ok_or(GroqError::InvalidToolCall {
+            source: anyhow::anyhow!("No arguments where found"),
+        })?;
 
         let parsed_args: Value = serde_json::from_str(&args_str)
             .map_err(|e| GroqError::MalformedResponse { source: e.into() })?;
 
-        if tool.function.name == "final_answer" {
-            return Ok(LlmOutcome::FinalAnswer {
-                answer: parsed_args,
-            });
-        }
-
-        Ok(LlmOutcome::ToolCall {
+        Ok(LlmToolCall {
             name: tool.function.name,
             id: tool.id,
             args: parsed_args,
         })
-
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {
@@ -83,7 +71,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_final_answer_tool() {
+    fn parses_final_answer() {
         let raw = json!({
             "choices": [{
                 "index": 0,
@@ -104,15 +92,9 @@ mod tests {
             }]
         });
 
-        let resp = parse(raw);
-        let outcome = LlmOutcome::try_from(resp).unwrap();
-
-        match outcome {
-            LlmOutcome::FinalAnswer { answer } => {
-                assert_eq!(answer, json!({"result": "done"}));
-            }
-            _ => panic!("Expected FinalAnswer"),
-        }
+        let result = LlmToolCall::try_from(parse(raw)).unwrap();
+        assert_eq!(result.name, "final_answer");
+        assert_eq!(result.args, json!({"result": "done"}));
     }
 
     #[test]
@@ -137,32 +119,17 @@ mod tests {
             }]
         });
 
-        let resp = parse(raw);
-        let outcome = LlmOutcome::try_from(resp).unwrap();
-
-        match outcome {
-            LlmOutcome::ToolCall { name, id, args } => {
-                assert_eq!(name, "git_status");
-                assert_eq!(id, "call_2");
-                assert_eq!(args, json!({"path": "."}));
-            }
-            _ => panic!("Expected ToolCall"),
-        }
+        let result = LlmToolCall::try_from(parse(raw)).unwrap();
+        assert_eq!(result.name, "git_status");
+        assert_eq!(result.id, "call_2");
+        assert_eq!(result.args, json!({"path": "."}));
     }
 
     #[test]
     fn fails_when_no_choices() {
-        let raw = json!({
-            "choices": []
-        });
-
-        let resp = parse(raw);
-        let result = LlmOutcome::try_from(resp);
-
-        assert!(matches!(
-            result,
-            Err(GroqError::MalformedResponse { .. })
-        ));
+        let raw = json!({ "choices": [] });
+        let result = LlmToolCall::try_from(parse(raw));
+        assert!(matches!(result, Err(GroqError::MalformedResponse { .. })));
     }
 
     #[test]
@@ -179,8 +146,8 @@ mod tests {
             }]
         });
 
-        let resp = parse(raw);
-        let _result = LlmOutcome::try_from(resp);
+        let result = LlmToolCall::try_from(parse(raw));
+        assert!(matches!(result, Err(GroqError::InvalidToolCall { .. })));
     }
 
     #[test]
@@ -198,7 +165,7 @@ mod tests {
             }]
         });
 
-        let resp = parse(raw);
-        let _result = LlmOutcome::try_from(resp);
+        let result = LlmToolCall::try_from(parse(raw));
+        assert!(matches!(result, Err(GroqError::InvalidToolCall { .. })));
     }
 }

--- a/src/tools/json.rs
+++ b/src/tools/json.rs
@@ -8,7 +8,7 @@ pub struct Json {
 
 impl Capability for Json {
     fn name(&self) -> &'static str {
-        "final_answe"
+        "final_answer"
     }
 
     fn metadata(&self) -> ToolFunction {
@@ -128,8 +128,8 @@ mod tests {
     #[test]
     fn metadata_name_is_final_answer() {
         let tool = json_tool(Script::schema());
-        assert_eq!(tool.name(), "json");
-        assert_eq!(tool.metadata().name, "json");
+        assert_eq!(tool.name(), "final_answer");
+        assert_eq!(tool.metadata().name, "final_answer");
     }
 
     #[test]

--- a/src/tools/json.rs
+++ b/src/tools/json.rs
@@ -1,0 +1,141 @@
+use serde_json::Value;
+use crate::core::capability::{Capability, ToolFunction};
+use super::error::ToolError;
+
+pub struct Json {
+    pub properties: Value,
+}
+
+impl Capability for Json {
+    fn name(&self) -> &'static str {
+        "final_answe"
+    }
+
+    fn metadata(&self) -> ToolFunction {
+        ToolFunction {
+            name: self.name().into(),
+            description: "Use this tool to submit your final answer. You MUST call this tool to complete your task — it is the only valid way to produce output.".into(),
+            parameters: self.properties.clone(),
+        }
+    }
+
+    fn execute(&self, args: Value) -> Result<String, ToolError> {
+         if self.properties.is_null() {
+            return Ok(args.to_string());
+        }
+
+        let validator = jsonschema::validator_for(&self.properties)
+            .map_err(|e| ToolError::ArgumentsParsing {
+                source: anyhow::anyhow!("Invalid contract schema: {}", e),
+            })?;
+
+        if validator.is_valid(&args) {
+            Ok(args.to_string())
+        } else {
+            let errors: Vec<String> = validator
+                .iter_errors(&args)
+                .map(|e| e.to_string())
+                .collect();
+            Err(ToolError::ArgumentsParsing {
+                source: anyhow::anyhow!("Contract violation: {}", errors.join(", ")),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+    use crate::utils::FlatSchema;
+
+    #[derive(JsonSchema, Deserialize)]
+    struct Script {
+        pub script: String,
+    }
+    impl FlatSchema for Script {}
+
+    #[derive(JsonSchema, Deserialize)]
+    struct NextCommand {
+        pub cmd: String,
+        pub man: String,
+    }
+    impl FlatSchema for NextCommand {}
+
+    fn json_tool(schema: Value) -> Json {
+        Json { properties: schema }
+    }
+
+    #[test]
+    fn accepts_valid_contract() {
+        let tool = json_tool(Script::schema());
+        let args = json!({ "script": "#!/bin/bash\necho hello" });
+        let result = tool.execute(args);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rejects_missing_required_field() {
+        let tool = json_tool(Script::schema());
+        let args = json!({});
+        let result = tool.execute(args);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_wrong_type() {
+        let tool = json_tool(Script::schema());
+        let args = json!({ "script": 42 });
+        let result = tool.execute(args);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_message_contains_field_name() {
+        let tool = json_tool(NextCommand::schema());
+        let args = json!({ "cmd": "ls" });
+        let result = tool.execute(args);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accepts_multi_field_contract() {
+        let tool = json_tool(NextCommand::schema());
+        let args = json!({ "cmd": "ls -la", "man": "list directory contents" });
+        let result = tool.execute(args);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn ok_returns_serialized_args() {
+        let tool = json_tool(Script::schema());
+        let args = json!({ "script": "echo test" });
+        let result = tool.execute(args.clone()).unwrap();
+        let round_trip: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(round_trip, args);
+    }
+
+    #[test]
+    fn null_schema_accepts_anything() {
+        let tool = json_tool(Value::Null);
+        let args = json!({ "anything": "goes" });
+        let result = tool.execute(args);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn metadata_name_is_final_answer() {
+        let tool = json_tool(Script::schema());
+        assert_eq!(tool.name(), "json");
+        assert_eq!(tool.metadata().name, "json");
+    }
+
+    #[test]
+    fn metadata_parameters_match_schema() {
+        let schema = Script::schema();
+        let tool = json_tool(schema.clone());
+        assert_eq!(tool.metadata().parameters, schema);
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -4,3 +4,4 @@ pub mod git_status;
 pub mod git_diff;
 pub mod git_log;
 pub mod read_dir;
+pub mod json;

--- a/tests/grog_integration.rs
+++ b/tests/grog_integration.rs
@@ -2,7 +2,7 @@
 mod integration {
     use smart_terminal::groq::client::GroqClient;
     use smart_terminal::core::llm_client::LLMProvider;
-    use smart_terminal::core::session::{AgentSession, AgentOutcome, ConversationEvent , Model , ModelName};
+    use smart_terminal::core::session::{AgentSession, Model, ModelName};
     use smart_terminal::core::capability::ToolFunction;
     use serde_json::json;
 
@@ -24,23 +24,19 @@ mod integration {
     }
 
     fn simple_session() -> AgentSession {
-        AgentSession {
-            events: vec![
-                ConversationEvent::System(
-                    "You are a helpful assistant. You MUST always respond by calling the final_answer tool.".into()
-                ),
-                ConversationEvent::User("What is 1 + 1?".into()),
-            ],
-            available_tools: vec![final_answer_tool()],
-            steps: 0,
-            model:Model::new(ModelName::GptOss120B, 0.7),
-        }
+        let mut session = AgentSession::new(
+            vec![final_answer_tool()],
+            5,
+            Model::new(ModelName::GptOss120B, 0.7),
+        );
+        session.add_system("You are a helpful assistant. You MUST always respond by calling the final_answer tool.");
+        session.add_user("What is 1 + 1?");
+        session
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
-    async fn complete_returns_final_answer() {
-
+    async fn complete_returns_tool_call() {
         dotenv::dotenv().ok();
 
         let key = std::env::var("GROQ_API_KEY")
@@ -57,14 +53,9 @@ mod integration {
 
         assert!(result.is_ok(), "complete() failed: {:?}", result.err());
 
-        match result.unwrap() {
-            AgentOutcome::FinalAnswer { arguments } => {
-                println!("Got final answer: {}", arguments);
-                assert!(arguments.get("result").is_some(), "missing 'result' key");
-            }
-            AgentOutcome::Tool { name, .. } => {
-                panic!("Expected FinalAnswer but got tool call: {}", name);
-            }
-        }
+        let call = result.unwrap();
+        println!("Got tool call: {} with args: {}", call.name(), call.arguments());
+        assert_eq!(call.name(), "final_answer");
+        assert!(call.arguments().get("result").is_some(), "missing 'result' key");
     }
 }


### PR DESCRIPTION
### **Title**
Refactor: Unify agent execution flow and simplify tool calling capabilities

### **Summary**
This PR simplifies the agent loop architecture by deprecating the `AgentOutcome` and `LlmOutcome` enums in favor of a unified `AgentToolCall` struct. It shifts how we handle "Final Answers" and JSON contracts, treating them as standard tool invocations rather than separate execution pathways. Furthermore, it tightens LLM constraints by enforcing tool usage at the provider level. 

### **Key Changes**

* **Unified Tool Executions:** * Removed `AgentOutcome` (and `LlmOutcome` from the Groq protocol) which previously split logic between `ToolCall` and `FinalAnswer`. 
    * Replaced with a singular `AgentToolCall` struct. The `FinalAnswer` concept is no longer a special struct in `capability.rs`; it is now handled naturally through standard tool resolution.
* **Session State Refactor:** * `AgentSession` now tracks the `last_tool` invoked. 
    * Loop resolution (`session.is_resolved()`) is now determined by checking if the last executed tool was `"final_answer"`, rather than relying on step exhaustion or matching specific outcome enums.
* **Request & Contract Simplification:** * Removed the standalone `contract` field from `AgentRequest`. 
    * JSON schema validation is now injected directly into the capabilities via the `Json` tool (`ToolNames::Json(schema)`), removing redundant contract validation logic in the agent loops.
* **Provider Constraint Updates:** * Updated the Groq adapter's `tool_choice` from `"auto"` to `"required"`. This forces the LLM to emit a tool call on every turn, reducing ambiguous text responses and improving loop predictability.
* **Test Maintenance:** Refactored unit tests across the `session`, `react`, and `groq` modules to accommodate the transition from `AgentOutcome` to `AgentToolCall`.